### PR TITLE
Support multiple kubernetes config file

### DIFF
--- a/src/quickAttach.ts
+++ b/src/quickAttach.ts
@@ -121,23 +121,23 @@ export async function quickAttach(context: ExtensionContext) {
     path: undefined,
   };
 
-  const path = await window.showInputBox({
+  const targetPath = await window.showInputBox({
     value: lastSelectedPath,
     placeHolder: "Input path",
   });
-
-  if (!path) {
+  
+  if (!targetPath) {
     return;
   }
-
-  context.globalState.update(key, { path });
-
+  
+  context.globalState.update(key, { path: targetPath });
+  
   const uri = Uri.from({
     scheme: "vscode-remote",
     authority: `k8s-container+${Object.entries(data)
       .map((xs) => xs.join("="))
       .join("+")}`,
-    path,
+    path: targetPath,
   });
 
   await commands.executeCommand("vscode.openFolder", uri, {

--- a/src/quickAttach.ts
+++ b/src/quickAttach.ts
@@ -25,8 +25,21 @@ interface Setting {
 }
 
 export async function quickAttach(context: ExtensionContext) {
+  const kubeDir = path.join(process.env.HOME || "", ".kube");
+  const configFiles = fs
+    .readdirSync(kubeDir)
+    .filter((f) => f.startsWith("config"));
+
+  const selectedConfig = await showQuickPick({
+    placeholder: "Select kubeconfig file",
+    items: configFiles.map((f) => ({ label: f })),
+    activeItemLabel: "config",
+  });
+
+  if (!selectedConfig) return;
+
   const kc = new k8s.KubeConfig();
-  kc.loadFromDefault();
+  kc.loadFromFile(path.join(kubeDir, selectedConfig));
 
   const targetContextName = await showQuickPick({
     placeholder: "Select Context",

--- a/src/quickAttach.ts
+++ b/src/quickAttach.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import { commands, ExtensionContext, Uri, window } from "vscode";
 import * as k8s from "@kubernetes/client-node";
 import { age, showQuickPick } from "./utils";


### PR DESCRIPTION
There is still one major issue, it runs `kubectl` without allowing us to specify the `KUBECONFIG` env... so all the flow works, I can select a pod present in a cluster that is not the default .kube/config but when vscode attaches:
<img width="367" height="145" alt="image" src="https://github.com/user-attachments/assets/86119f8f-15aa-4009-998c-7ecc1857ab44" />
